### PR TITLE
Remove duplicate imports from splunk sdk

### DIFF
--- a/modules/splunk_sdk.py
+++ b/modules/splunk_sdk.py
@@ -1,9 +1,7 @@
 
 import sys
-from time import sleep
 import splunklib.results as results
 import splunklib.client as client
-import splunklib.results as results
 import requests
 
 


### PR DESCRIPTION
## Summary
- clean up `modules/splunk_sdk.py`

## Testing
- `python3 -m py_compile modules/splunk_sdk.py`


------
https://chatgpt.com/codex/tasks/task_e_6851d48212908328b656d919ea32eb5d